### PR TITLE
feat: make dse reload clear stack and re-fetch all secrets

### DIFF
--- a/_dotsecenv_core.sh
+++ b/_dotsecenv_core.sh
@@ -46,9 +46,12 @@ _dotsecenv_stack_push() {
 _dotsecenv_stack_pop() {
     # Remove last element from stack
     # Note: zsh's unset 'arr[-1]' empties the element but doesn't shrink
-    # the array inside functions, so use slice assignment instead
-    if [[ -n "$ZSH_VERSION" ]]; then
-        _DOTSECENV_SOURCE_STACK=("${(@)_DOTSECENV_SOURCE_STACK[1,-2]}")
+    # the array inside functions, so use slice reassignment instead
+    local len=${#_DOTSECENV_SOURCE_STACK[@]}
+    if [[ $len -eq 0 ]]; then
+        return
+    elif [[ -n "$ZSH_VERSION" ]]; then
+        _DOTSECENV_SOURCE_STACK=("${_DOTSECENV_SOURCE_STACK[@]:0:$((len - 1))}")
     else
         unset '_DOTSECENV_SOURCE_STACK[-1]'
     fi
@@ -687,7 +690,10 @@ _dotsecenv_reload() {
     if [[ -f "$PWD/.secenv" ]]; then
         local already_loaded=0
         for dir in "${dirs_to_reload[@]}"; do
-            [[ "$dir" == "$PWD" ]] && { already_loaded=1; break; }
+            [[ "$dir" == "$PWD" ]] && {
+                already_loaded=1
+                break
+            }
         done
         if [[ $already_loaded -eq 0 ]]; then
             _dotsecenv_on_cd "" "$PWD"

--- a/_dotsecenv_core.sh
+++ b/_dotsecenv_core.sh
@@ -44,8 +44,14 @@ _dotsecenv_stack_push() {
 }
 
 _dotsecenv_stack_pop() {
-    # Remove last element from stack (works in both bash and zsh)
-    unset '_DOTSECENV_SOURCE_STACK[-1]'
+    # Remove last element from stack
+    # Note: zsh's unset 'arr[-1]' empties the element but doesn't shrink
+    # the array inside functions, so use slice assignment instead
+    if [[ -n "$ZSH_VERSION" ]]; then
+        _DOTSECENV_SOURCE_STACK=("${(@)_DOTSECENV_SOURCE_STACK[1,-2]}")
+    else
+        unset '_DOTSECENV_SOURCE_STACK[-1]'
+    fi
 }
 
 _dotsecenv_stack_top() {
@@ -656,11 +662,44 @@ _dotsecenv_clipboard_copy() {
     return 1
 }
 
+# Reload all .secenv files - clears stack and re-fetches everything fresh
+# Use when vault secrets have been updated and you want to refresh without cd-ing out
+_dotsecenv_reload() {
+    # Save current stack entries (ancestor → descendant order)
+    local -a dirs_to_reload=("${_DOTSECENV_SOURCE_STACK[@]}")
+
+    # Clear the entire stack and unload all variables
+    while [[ ${#_DOTSECENV_SOURCE_STACK[@]} -gt 0 ]]; do
+        local top="${_DOTSECENV_SOURCE_STACK[-1]}"
+        _dotsecenv_stack_pop
+        _dotsecenv_unload_dir "$top"
+    done
+
+    # Re-load each directory in original order (ancestor → descendant)
+    local dir
+    for dir in "${dirs_to_reload[@]}"; do
+        if [[ -f "$dir/.secenv" ]]; then
+            _dotsecenv_on_cd "" "$dir"
+        fi
+    done
+
+    # Also pick up current dir if it now has .secenv and wasn't previously loaded
+    if [[ -f "$PWD/.secenv" ]]; then
+        local already_loaded=0
+        for dir in "${dirs_to_reload[@]}"; do
+            [[ "$dir" == "$PWD" ]] && { already_loaded=1; break; }
+        done
+        if [[ $already_loaded -eq 0 ]]; then
+            _dotsecenv_on_cd "" "$PWD"
+        fi
+    fi
+}
+
 # Aliases - defined as functions to work in both bash and zsh
 dse() {
     case "${1:-}" in
     reload)
-        _dotsecenv_chpwd_hook
+        _dotsecenv_reload
         ;;
     get)
         shift

--- a/conf.d/dotsecenv.fish
+++ b/conf.d/dotsecenv.fish
@@ -587,9 +587,36 @@ function _dotsecenv_cd_hook --on-variable PWD
     _dotsecenv_on_cd "$old_dir" "$new_dir"
 end
 
+# Reload all .secenv files - clears stack and re-fetches everything fresh
+function _dotsecenv_reload
+    # Save current stack entries (ancestor → descendant order)
+    set -l dirs_to_reload $_DOTSECENV_SOURCE_STACK
+
+    # Clear the entire stack and unload all variables
+    while test (count $_DOTSECENV_SOURCE_STACK) -gt 0
+        set -l top $_DOTSECENV_SOURCE_STACK[-1]
+        _dotsecenv_stack_pop
+        _dotsecenv_unload_dir "$top"
+    end
+
+    # Re-load each directory in original order (ancestor → descendant)
+    for dir in $dirs_to_reload
+        if test -f "$dir/.secenv"
+            _dotsecenv_on_cd "" "$dir"
+        end
+    end
+
+    # Also pick up current dir if it now has .secenv and wasn't previously loaded
+    if test -f "$PWD/.secenv"
+        if not contains "$PWD" $dirs_to_reload
+            _dotsecenv_on_cd "" "$PWD"
+        end
+    end
+end
+
 # Reload secrets in current directory
 function reloadsecenv
-    _dotsecenv_on_cd "$PWD" "$PWD"
+    _dotsecenv_reload
 end
 
 # Clipboard helper - copies stdin to clipboard
@@ -632,7 +659,7 @@ function dse
 
     switch $argv[1]
         case reload
-            _dotsecenv_on_cd "$PWD" "$PWD"
+            _dotsecenv_reload
         case get
             dotsecenv secret get $argv[2..]
         case cp

--- a/dotsecenv.plugin.bash
+++ b/dotsecenv.plugin.bash
@@ -35,7 +35,7 @@ _dotsecenv_chpwd_hook() {
 
 # Reload secrets in current directory
 reloadsecenv() {
-    _dotsecenv_on_cd "$PWD" "$PWD"
+    _dotsecenv_reload
 }
 
 # Use PROMPT_COMMAND to detect directory changes (bash has no chpwd hook)

--- a/dotsecenv.plugin.zsh
+++ b/dotsecenv.plugin.zsh
@@ -35,7 +35,7 @@ _dotsecenv_chpwd_hook() {
 
 # Reload secrets in current directory (for when cd . doesn't trigger chpwd)
 reloadsecenv() {
-    _dotsecenv_on_cd "$PWD" "$PWD"
+    _dotsecenv_reload
 }
 
 # Register the chpwd hook using zsh's hook system

--- a/tests/test_plugins.sh
+++ b/tests/test_plugins.sh
@@ -1151,6 +1151,163 @@ test_dse_up_no_ancestors() {
 }
 
 # ============================================================================
+# dse reload Tests
+# ============================================================================
+
+test_dse_reload_refreshes_values() {
+    local shell="$1"
+    log "[$shell] Testing 'dse reload' refreshes secret values..."
+    ((TESTS_RUN++)) || true
+
+    local test_dir="$TEMP_DIR/test_dse_reload_refresh"
+    mkdir -p "$test_dir/project"
+
+    cat >"$test_dir/project/.secenv" <<'EOF'
+DB_PASSWORD={dotsecenv}
+APP_NAME=original
+EOF
+    chmod 644 "$test_dir/project/.secenv"
+
+    # Create a mock that changes its return value based on a flag file
+    local mock_dir="$TEMP_DIR/mock_bin_reload"
+    mkdir -p "$mock_dir"
+    cat >"$mock_dir/dotsecenv" <<MOCK_EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "secret" && "\$2" == "get" ]]; then
+    if [[ -f "$test_dir/updated_flag" ]]; then
+        case "\$3" in
+            "DB_PASSWORD") echo "new-secret-password" ;;
+            *) exit 1 ;;
+        esac
+    else
+        case "\$3" in
+            "DB_PASSWORD") echo "old-secret-password" ;;
+            *) exit 1 ;;
+        esac
+    fi
+else
+    exit 1
+fi
+MOCK_EOF
+    chmod +x "$mock_dir/dotsecenv"
+
+    local result
+    if [[ "$shell" == "bash" ]]; then
+        result=$("$BASH_BIN" -c "
+            export PATH='$mock_dir:$PATH'
+            export DOTSECENV_CONFIG_DIR='$TEMP_DIR/config_reload'
+            mkdir -p '$TEMP_DIR/config_reload'
+            echo '$test_dir/project' > '$TEMP_DIR/config_reload/trusted_dirs'
+            source '$SHELL_DIR/_dotsecenv_core.sh'
+            source '$SHELL_DIR/dotsecenv.plugin.bash'
+            cd '$test_dir/project'
+            _dotsecenv_chpwd_hook
+            local before_secret=\"\$DB_PASSWORD\"
+            local before_plain=\"\$APP_NAME\"
+            # Simulate vault update
+            touch '$test_dir/updated_flag'
+            # Also update the plain value
+            echo 'DB_PASSWORD={dotsecenv}' > '$test_dir/project/.secenv'
+            echo 'APP_NAME=updated' >> '$test_dir/project/.secenv'
+            dse reload
+            echo \"before_secret=\$before_secret|after_secret=\$DB_PASSWORD|before_plain=\$before_plain|after_plain=\$APP_NAME\"
+        " 2>/dev/null)
+    else
+        result=$(zsh -c "
+            export PATH='$mock_dir:$PATH'
+            export DOTSECENV_CONFIG_DIR='$TEMP_DIR/config_reload'
+            mkdir -p '$TEMP_DIR/config_reload'
+            echo '$test_dir/project' > '$TEMP_DIR/config_reload/trusted_dirs'
+            source '$SHELL_DIR/dotsecenv.plugin.zsh'
+            cd '$test_dir/project'
+            local before_secret=\"\$DB_PASSWORD\"
+            local before_plain=\"\$APP_NAME\"
+            # Simulate vault update
+            touch '$test_dir/updated_flag'
+            # Also update the plain value
+            echo 'DB_PASSWORD={dotsecenv}' > '$test_dir/project/.secenv'
+            echo 'APP_NAME=updated' >> '$test_dir/project/.secenv'
+            dse reload
+            echo \"before_secret=\$before_secret|after_secret=\$DB_PASSWORD|before_plain=\$before_plain|after_plain=\$APP_NAME\"
+        " 2>/dev/null)
+    fi
+
+    rm -f "$test_dir/updated_flag"
+
+    if [[ "$result" == *"after_secret=new-secret-password"* && "$result" == *"after_plain=updated"* ]]; then
+        pass "[$shell] 'dse reload' refreshes both secret and plain values"
+    else
+        fail "[$shell] 'dse reload' refresh failed, got: $result"
+    fi
+}
+
+test_dse_reload_clears_and_reloads_stack() {
+    local shell="$1"
+    log "[$shell] Testing 'dse reload' clears and reloads nested stack..."
+    ((TESTS_RUN++)) || true
+
+    local test_dir="$TEMP_DIR/test_dse_reload_stack"
+    mkdir -p "$test_dir/root/project"
+
+    cat >"$test_dir/root/.secenv" <<'EOF'
+APP_ENV=production
+EOF
+    chmod 644 "$test_dir/root/.secenv"
+
+    cat >"$test_dir/root/project/.secenv" <<'EOF'
+DB_PASSWORD={dotsecenv}
+EOF
+    chmod 644 "$test_dir/root/project/.secenv"
+
+    local mock_path
+    mock_path=$(create_mock_dotsecenv)
+
+    local result
+    if [[ "$shell" == "bash" ]]; then
+        result=$("$BASH_BIN" -c "
+            export PATH='$mock_path:$PATH'
+            export DOTSECENV_CONFIG_DIR='$TEMP_DIR/config_reload_stack'
+            mkdir -p '$TEMP_DIR/config_reload_stack'
+            echo '$test_dir/root' > '$TEMP_DIR/config_reload_stack/trusted_dirs'
+            echo '$test_dir/root/project' >> '$TEMP_DIR/config_reload_stack/trusted_dirs'
+            source '$SHELL_DIR/_dotsecenv_core.sh'
+            source '$SHELL_DIR/dotsecenv.plugin.bash'
+            cd '$test_dir/root'
+            _dotsecenv_chpwd_hook
+            cd '$test_dir/root/project'
+            _dotsecenv_chpwd_hook
+            # Both should be loaded now
+            local before_env=\"\$APP_ENV\"
+            local before_pw=\"\$DB_PASSWORD\"
+            # Run reload from the nested dir
+            dse reload
+            echo \"before_env=\$before_env|after_env=\$APP_ENV|before_pw=\$before_pw|after_pw=\$DB_PASSWORD|stack=\${_DOTSECENV_SOURCE_STACK[*]}\"
+        " 2>/dev/null)
+    else
+        result=$(zsh -c "
+            export PATH='$mock_path:$PATH'
+            export DOTSECENV_CONFIG_DIR='$TEMP_DIR/config_reload_stack'
+            mkdir -p '$TEMP_DIR/config_reload_stack'
+            echo '$test_dir/root' > '$TEMP_DIR/config_reload_stack/trusted_dirs'
+            echo '$test_dir/root/project' >> '$TEMP_DIR/config_reload_stack/trusted_dirs'
+            source '$SHELL_DIR/dotsecenv.plugin.zsh'
+            cd '$test_dir/root'
+            cd '$test_dir/root/project'
+            local before_env=\"\$APP_ENV\"
+            local before_pw=\"\$DB_PASSWORD\"
+            dse reload
+            echo \"before_env=\$before_env|after_env=\$APP_ENV|before_pw=\$before_pw|after_pw=\$DB_PASSWORD|stack=\${_DOTSECENV_SOURCE_STACK[*]}\"
+        " 2>/dev/null)
+    fi
+
+    if [[ "$result" == *"after_env=production"* && "$result" == *"after_pw=super-secret-password"* ]]; then
+        pass "[$shell] 'dse reload' reloads entire nested stack"
+    else
+        fail "[$shell] 'dse reload' nested stack reload failed, got: $result"
+    fi
+}
+
+# ============================================================================
 # Main
 # ============================================================================
 
@@ -1196,6 +1353,8 @@ main() {
         test_dse_up_multiple_ancestors "bash"
         test_dse_up_skips_already_loaded "bash"
         test_dse_up_no_ancestors "bash"
+        test_dse_reload_refreshes_values "bash"
+        test_dse_reload_clears_and_reloads_stack "bash"
     fi
 
     # Run zsh tests
@@ -1225,6 +1384,8 @@ main() {
             test_dse_up_multiple_ancestors "zsh"
             test_dse_up_skips_already_loaded "zsh"
             test_dse_up_no_ancestors "zsh"
+            test_dse_reload_refreshes_values "zsh"
+            test_dse_reload_clears_and_reloads_stack "zsh"
         else
             warn "Zsh not found, skipping zsh tests"
         fi


### PR DESCRIPTION
## Summary

- **`dse reload` now actually reloads**: Previously it was a no-op when staying in the same directory. Now it clears the entire stack and re-fetches all `.secenv` values fresh — equivalent to `cd /` then `cd` back.
- **Fix zsh `_dotsecenv_stack_pop` bug**: zsh's `unset 'arr[-1]'` inside functions empties the element but doesn't shrink the array. This caused infinite loops in the new reload logic and was a latent bug in existing code. Fixed with slice assignment on zsh.
- **Fish parity**: Equivalent `_dotsecenv_reload` function added to the fish implementation.

## Test plan

- [x] All 44 existing + new E2E tests pass (bash and zsh)
- [x] `test_dse_reload_refreshes_values` — verifies updated vault secrets and plain values are picked up after reload
- [x] `test_dse_reload_clears_and_reloads_stack` — verifies nested ancestor+descendant stacks reload correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)