### PR TITLE
docs: state actual ownership rule and surface both refusal messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Shell plugins for [dotsecenv](https://github.com/dotsecenv/dotsecenv) that autom
 - Automatically loads `.env` and `.secenv` files when you `cd` into a directory
 - Unsets environment variables when you leave the directory
 - Fetches secrets from your dotsecenv vault using the `{dotsecenv}` or `{dotsecenv/KEY}` syntax
-- Security checks: refuses to load world-writable files or files not owned by you
+- Security checks: refuses to load world-writable files or files not owned by you (or root)
 - Trust system: prompts before loading `.secenv` files from untrusted directories
 - Convenient aliases: `dse`, `secret`, `copysecret`
 
@@ -180,11 +180,14 @@ The plugins perform security checks before loading files:
 1. **Ownership**: Files must be owned by the current user or root
 2. **Permissions**: Files must not be world-writable
 
-If a file fails these checks, it will be refused with a warning:
+If a file fails these checks, the plugin refuses to source it and prints one of:
 
 ```shell
 dotsecenv: refusing to load /path/.secenv - world-writable
+dotsecenv: refusing to load /path/.secenv - not owned by current user or root
 ```
+
+`chmod go-w .secenv` is enough to satisfy the permissions check; `chmod 600` works too. The ownership check accepts files owned by either the current user (`id -u`) or root (UID 0).
 
 ## Configuration
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,8 +37,8 @@ Please provide:
 
 The shell plugins include several security measures:
 
-- **File ownership checks**: Refuses to load files not owned by you
-- **Permission checks**: Refuses to load world-writable files
+- **File ownership checks**: Refuses to load files not owned by the current user or root (UID 0)
+- **Permission checks**: Refuses to load world-writable files (any mode with the `o+w` bit set)
 - **Trust system**: Prompts before loading `.secenv` files from untrusted directories
 - **No eval of untrusted content**: Values are not executed as shell commands
 


### PR DESCRIPTION
## Summary
The security checks in `_dotsecenv_core.sh` (and the matching `conf.d/dotsecenv.fish`) accept files owned by the current user **or root** and reject files when the world-write bit is set. Previous wording was tighter than reality:

- **README.md** Features bullet and Security section said "files not owned by you" (omitting root) and showed only the world-writable refusal message — leaving the second variant undocumented.
- **SECURITY.md** had the same omission.

This PR aligns both files with the code:

- Ownership rule says "current user or root (UID 0)".
- Permission rule clarifies the actual check is "any mode with the `o+w` bit set" — so `chmod go-w` is enough; `chmod 600` is not mandatory.
- README's Security section now lists both real refusal messages so users hitting the ownership variant can find it via search.

No code changes; behavior is unchanged.

## Test plan
- [x] Wording cross-checked against `_dotsecenv_core.sh:67-106` and `conf.d/dotsecenv.fish:80-107`
- [x] Both refusal strings copied verbatim from the source
- [ ] Render README on GitHub and confirm the code block displays both lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)