### PR TITLE
docs: mark this repo as artifact-only; source moved to dotsecenv/dotsecenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dotsecenv/plugin
 
+> **⚠️ Source has moved.** This repository is now an **artifact-only publish target**. The shell plugin source of truth lives in [`dotsecenv/dotsecenv`](https://github.com/dotsecenv/dotsecenv) at [`plugin/`](https://github.com/dotsecenv/dotsecenv/tree/main/plugin). Open issues and pull requests against `dotsecenv/dotsecenv`. Releases continue to publish to this repo for installation via plugin managers.
+
 [![Shell plugins CI](https://github.com/dotsecenv/plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/dotsecenv/plugin/actions/workflows/ci.yml)
 
 Shell plugins for [dotsecenv](https://github.com/dotsecenv/dotsecenv) that automatically load `.env` and `.secenv` files when entering directories.


### PR DESCRIPTION
> 🚧 **Draft.** Coordinated with the monorepo migration PR (dotsecenv/dotsecenv#136). Merge in lockstep — the banner here is premature until the source has actually moved.

## Summary

Adds a banner to README.md announcing that this repository is now an artifact-only publish target. The shell plugin source of truth lives in [`dotsecenv/dotsecenv`](https://github.com/dotsecenv/dotsecenv) at `plugin/`. Each release pushes the latest source from the monorepo here for plugin-manager installs (oh-my-zsh, fisher, etc.) to continue working.

## Test plan

- [ ] Merge after dotsecenv/dotsecenv#136 (PR 1 of the monorepo migration) is verified on an rc tag.
- [ ] Confirm plugin-manager users (`oh-my-zsh`, `fisher`, etc.) still see the latest source after a release.
- [ ] Confirm the README renders correctly on github.com with the banner visible above the badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)